### PR TITLE
fix: display total commit count on homepage

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,8 +1,7 @@
 import { building } from "$app/environment";
-import { DISCORD_USER_TOKEN, GITLAB_API_TOKEN } from "$env/static/private";
+import { DISCORD_USER_TOKEN } from "$env/static/private";
 
 let memberCount = 0;
-let starCount = 0;
 let roleMembers = {
 	"1214817156420862012": 50,
 };
@@ -20,20 +19,20 @@ async function fetchServerSideData() {
 					},
 				})
 			: Promise.resolve({ json: () => roleMembers }),
-		fetch("https://git.suyu.dev/api/v1/repos/suyu/suyu"),
+		fetch('https://git.suyu.dev/api/v1/repos/suyu/suyu/commits?stat=false&verification=false&files=false&limit=1')
 	];
 
-	const [res, roles, gitlabRes, suyuGitRes] = await Promise.all(promises);
-	const jsonPromises = [res.json(), roles.json(), gitlabRes.json()];
-	const [resJson, rolesJson, gitResJson] = await Promise.all(jsonPromises);
+	const [res, roles, git] = await Promise.all(promises);
+	const jsonPromises = [res.json(), roles.json()];
+	const [resJson, rolesJson] = await Promise.all(jsonPromises);
 
 	
 	memberCount = resJson.approximate_member_count;
-	gitCommits = parseInt(suyuGitRes?.headers?.get('x-total'), 10) || 0;
+	gitCommits = parseInt(git?.headers?.get('x-total'), 10) || 0;
 	if (DISCORD_USER_TOKEN) roleMembers = rolesJson;
 
 	console.log("Member count:", memberCount);
-	console.log('Git commit count', gitCommits);
+	console.log('Git commit count:', gitCommits);
 }
 
 if (!building) {
@@ -46,7 +45,6 @@ export async function load({ cookies }) {
 	return {
 		tokenCookie: token,
 		memberCount,
-		starCount,
 		roleMembers,
 		gitCommits
 	};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,6 @@
 	export let data: PageData;
 	$: memberCount = parseFloat(data.memberCount?.toPrecision(2));
 	$: contributors = parseFloat(data.roleMembers?.["1214817156420862012"]?.toPrecision(2));
-	$: starCount = parseFloat(data.starCount?.toPrecision(2));
 	$: gitCommits = parseFloat(data.gitCommits?.toPrecision(2));
 	let metadata = {
 		url: "https://suyu.dev",


### PR DESCRIPTION
Also I've cleaned up the `+page.server.ts` file a little bit. The commit count data is only available as a response header value under the `/commits/` API path. This should be working as expected now. Let me know if there is an easier way to fetch this data.